### PR TITLE
Fixing double newlines

### DIFF
--- a/srcs/builtins/builtins.c
+++ b/srcs/builtins/builtins.c
@@ -6,7 +6,7 @@
 /*   By: abeznik <abeznik@student.codam.nl>           +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2022/10/05 19:02:19 by abeznik       #+#    #+#                 */
-/*   Updated: 2023/05/18 14:53:04 by nsterk        ########   odam.nl         */
+/*   Updated: 2023/05/18 15:09:21 by nsterk        ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -45,6 +45,7 @@ int	check_builtin(t_cmd *cmds, t_data_exe *data_exe)
 	
 	tmp = cmds->args[0]; // ? testing
 	// this is a comment
+	// this is a comment 1
 	if (!cmds)
 		return (EXIT_FAILURE);
 	if (!ft_strncmp(tmp, "echo", 5))


### PR DESCRIPTION
These functions fail with double newlines:
- [ ] echo
- [ ] export