### PR TITLE
Fix quotes 2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,7 @@ SRCS_UTILS		:=	exits.c \
 					ft_putendl_fd.c \
 					ft_putnbr_fd.c \
 					ft_putstr_fd.c \
+					ft_replace.c \
 					ft_skipspace.c \
 					ft_split.c \
 					ft_strcheck.c \
@@ -97,6 +98,7 @@ SRCS_UTILS		:=	exits.c \
 					ft_strlen.c \
 					ft_strncmp.c \
 					ft_strndup.c \
+					ft_substr.c \
 					token_append.c \
 					token_last.c \
 					token_clear.c \

--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,8 @@ SRCS_UTILS		:=	exits.c \
 					token_new.c \
 					malloc_check.c \
 					strjoin_free.c \
-					test_list.c
+					test_list.c \
+					test_parser.c 
 
 
 # Objects

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ SRCS_LEXER		:=	delimit_token.c \
 					lex_operator.c \
 					lex_space.c \
 					lex_word.c \
+					lex_quote.c \
 					state_type.c \
 
 # Expander srcs
@@ -103,6 +104,7 @@ SRCS_UTILS		:=	exits.c \
 					token_new.c \
 					malloc_check.c \
 					strjoin_free.c \
+					test_list.c
 
 
 # Objects

--- a/includes/defines.h
+++ b/includes/defines.h
@@ -2,12 +2,12 @@
 #ifndef DEFINES_H
 # define DEFINES_H
 
-# define CH_SQUOTE		'\''
-# define CH_DQUOTE 		'"'
-# define CH_PIPE		'|'
-# define CH_REDIR_IN	'<'
-# define CH_REDIR_OUT	'>'
-# define CH_EXPAND		'$'
+# define CH_SQUOTE	'\''
+# define CH_DQUOTE 	'"'
+# define CH_PIPE	'|'
+# define CH_LESS	'<'
+# define CH_GREAT	'>'
+# define CH_EXPAND	'$'
 
 /**
  * Token flags. Flags are set in one int, with different bits corresponding
@@ -19,13 +19,12 @@
  * F_APPEND		special redirection (heredoc for redir_in, append for redir_out)
  */
 
-# define SQUOTE		1
-# define DQUOTE		2
-# define LESS		4
-# define DLESS		8
-# define GREAT		16
-# define DGREAT		32
-# define F_APPEND	64
-# define F_EXPAND	128
+# define F_SQUOTE	1
+# define F_DQUOTE	2
+# define F_OPERATOR	16
+# define F_SPACE	32
+# define F_WORD		128
+# define F_EXPAND	256
+# define F_APPEND	512
 
 #endif

--- a/includes/lexer.h
+++ b/includes/lexer.h
@@ -11,11 +11,13 @@
 
 typedef enum e_toktype
 {
-	TOK_WRD,
+	TOK_SPACE,
+	TOK_DQUOTE,
+	TOK_SQUOTE,
 	TOK_REDIR_IN,
 	TOK_REDIR_OUT,
 	TOK_PIPE,
-	TOK_SPACE,
+	TOK_WRD,
 	TOK_EOF,
 	TOK_MAX
 }	t_toktype;
@@ -23,11 +25,14 @@ typedef enum e_toktype
 typedef enum e_lexstate
 {
 	S_SPACE,
+	S_DQUOTE,
+	S_SQUOTE,
 	S_REDIR_IN,
 	S_REDIR_OUT,
 	S_PIPE,
 	S_WORD,
-	S_EOF
+	S_EOF,
+	S_MAX
 }	t_lexstate;
 
 typedef struct s_expansion
@@ -36,7 +41,6 @@ typedef struct s_expansion
 	size_t	end;
 	int		quoted;
 	char 	*parameter;
-	
 }	t_expansion;
 
 typedef struct s_token
@@ -71,6 +75,7 @@ void		delimit_token(t_lexer *lexer, size_t start, t_toktype type);
 typedef bool	(*t_lexfunction)(t_lexer *lexer, t_toktype type);
 bool		lex_operator(t_lexer *lexer, t_toktype type);
 bool		lex_word(t_lexer *lexer, t_toktype type);
+bool		lex_quote(t_lexer *lexer, t_toktype type);
 bool		lex_space(t_lexer *lexer, t_toktype type);
 
 void		switch_state(t_lexer *lexer, t_lexstate new_state);

--- a/includes/test.h
+++ b/includes/test.h
@@ -12,6 +12,6 @@ void	token_printHtT(t_token *lst);
 /* Print tokens tail to head */
 void	token_printTtH(t_token *lst);
 
-void	print_tbl(t_cmd *cmd);
+void	print_tbl(t_cmd *cmd);  
 
 #endif

--- a/includes/utils.h
+++ b/includes/utils.h
@@ -49,7 +49,6 @@ int					ft_atoi(const char *str);
 void				ft_bzero(void *s, size_t n);
 void				*ft_calloc(size_t count, size_t size);
 char				*ft_itoa(int n);
-// int					ft_isspace(int c);
 void				*ft_memcpy(void *dst, const void *src, size_t n);
 // void				*ft_memccpy(void *dst, const void *src, int c, size_t n);
 // void				*ft_memchr(const void *s, int c, size_t n);
@@ -69,7 +68,7 @@ size_t				ft_strlen(const char *s);
 int					ft_strncmp(const char *s1, const char *s2, size_t len);
 // int					ft_strcmp(char *s1, char *s2);
 // char				*ft_strtrim(char const *s1, char const *set);
-// char				*ft_substr(char const *s, unsigned int start, size_t len);
+char				*ft_substr(char const *s, size_t start, size_t len);
 const char			*ft_skipspace(const char *str);
 int					ft_free_array(char **str);
 size_t				ft_array_len(char **arr);
@@ -81,7 +80,7 @@ int					ft_isdigit(int c);
 int					ft_strcheck(char const *s, int (*f)(int));
 int					ft_isalpha(int c);
 int					ft_isalnum(int c);
-// int					ft_isalpha(int c);
+char				*ft_replace(char *dst, char *src, size_t start, size_t end);
 
 
 #	endif

--- a/srcs/expander/prep_expansion.c
+++ b/srcs/expander/prep_expansion.c
@@ -37,7 +37,7 @@ static int		st_prep_token(t_token *token)
 			}
 			pos++;
 		}
-		// printf("exp[%zu].start: %zu	exp[%zu].end: %zu	exp[%zu].param: %s\n", i, token->exp[i].start, i, token->exp[i].end, i, token->exp[i].parameter);
+		printf("exp[%zu].start: %zu	exp[%zu].end: %zu	exp[%zu].param: %s\n", i, token->exp[i].start, i, token->exp[i].end, i, token->exp[i].parameter);
 		i++;
 	}
 	return (0);

--- a/srcs/lexer/delimit_token.c
+++ b/srcs/lexer/delimit_token.c
@@ -13,4 +13,5 @@ void	delimit_token(t_lexer *lex, size_t start, t_toktype type)
 	if (token_append(&(lex->tokens), new))
 		exit(EXIT_FAILURE);
 	lex->expansions = 0;
+	lex->flags = 0;
 }

--- a/srcs/lexer/delimit_token.c
+++ b/srcs/lexer/delimit_token.c
@@ -10,6 +10,8 @@ void	delimit_token(t_lexer *lex, size_t start, t_toktype type)
 		ft_strndup(lex->str + start, lex->idx - start + 1), lex->expansions);
 	check_malloc(new, "delimit_token");
 	new->flags = lex->flags;
+	if (type == TOK_WRD)
+		new->flags |= F_WORD;
 	if (token_append(&(lex->tokens), new))
 		exit(EXIT_FAILURE);
 	lex->expansions = 0;

--- a/srcs/lexer/lex_operator.c
+++ b/srcs/lexer/lex_operator.c
@@ -8,11 +8,10 @@ bool	lex_operator(t_lexer *lex, t_toktype type)
 
 	if (type != TOK_PIPE && c == lex->str[lex->idx + 1])
 	{
-		// if (lex->str[lex->idx + 1] && lex->str[lex->idx + 2] == c)
-		// 	return (error_msg("Syntax error: lex_operator"));
 		lex->flags |= F_APPEND;
 		lex->idx++;
 	}
+	lex->flags |= F_OPERATOR;
 	delimit_token(lex, start, type);
 	switch_state(lex, get_state(lex->str[lex->idx + 1]));
 	return (false);

--- a/srcs/lexer/lex_quote.c
+++ b/srcs/lexer/lex_quote.c
@@ -8,12 +8,16 @@ bool	lex_quote(t_lexer *lexer, t_toktype type)
 	int		quote;
 
 	quote = lexer->str[lexer->idx];
+	if (type == TOK_SQUOTE)
+		lexer->flags += F_SQUOTE;
+	if (type == TOK_DQUOTE)
+		lexer->flags += F_DQUOTE;
 	if (!ft_strchr(lexer->str + lexer->idx + 1, quote))
 		return (error_msg("Unclosed quotes not supported by momoshell"));
-	lexer->idx++;
-	start = lexer->idx;
-	if (type == TOK_DQUOTE && lexer->str[start] == CH_EXPAND)
-		lexer->expansions++;
+	// lexer->idx++;
+	start = lexer->idx + 1;
+	// if (type == TOK_DQUOTE && lexer->str[start] == CH_EXPAND)
+	// 	lexer->expansions++;
 	while (lexer->str[lexer->idx + 1] != quote)
 	{
 		lexer->idx++;
@@ -22,7 +26,6 @@ bool	lex_quote(t_lexer *lexer, t_toktype type)
 	}
 	delimit_token(lexer, start, type);
 	lexer->idx++;
-	// lexer->idx--;
 	switch_state(lexer, get_state(lexer->str[lexer->idx + 1]));
 	return (false);
 }

--- a/srcs/lexer/lex_quote.c
+++ b/srcs/lexer/lex_quote.c
@@ -1,0 +1,28 @@
+
+#include "lexer.h"
+bool	error_msg(char *msg);
+
+bool	lex_quote(t_lexer *lexer, t_toktype type)
+{
+	size_t	start;
+	int		quote;
+
+	quote = lexer->str[lexer->idx];
+	if (!ft_strchr(lexer->str + lexer->idx + 1, quote))
+		return (error_msg("Unclosed quotes not supported by momoshell"));
+	lexer->idx++;
+	start = lexer->idx;
+	if (type == TOK_DQUOTE && lexer->str[start] == CH_EXPAND)
+		lexer->expansions++;
+	while (lexer->str[lexer->idx + 1] != quote)
+	{
+		lexer->idx++;
+		if (quote == CH_DQUOTE && lexer->str[lexer->idx] == CH_EXPAND)
+			lexer->expansions++;
+	}
+	delimit_token(lexer, start, type);
+	lexer->idx++;
+	// lexer->idx--;
+	switch_state(lexer, get_state(lexer->str[lexer->idx + 1]));
+	return (false);
+}

--- a/srcs/lexer/lex_quote.c
+++ b/srcs/lexer/lex_quote.c
@@ -1,6 +1,6 @@
 
-#include "lexer.h"
-bool	error_msg(char *msg);
+#include "minishell.h"
+// bool	error_msg(char *msg);
 
 bool	lex_quote(t_lexer *lexer, t_toktype type)
 {
@@ -9,15 +9,13 @@ bool	lex_quote(t_lexer *lexer, t_toktype type)
 
 	quote = lexer->str[lexer->idx];
 	if (type == TOK_SQUOTE)
-		lexer->flags += F_SQUOTE;
+		lexer->flags |= F_SQUOTE;
 	if (type == TOK_DQUOTE)
-		lexer->flags += F_DQUOTE;
+		lexer->flags |= F_DQUOTE;
+	lexer->flags |= F_WORD;
 	if (!ft_strchr(lexer->str + lexer->idx + 1, quote))
 		return (error_msg("Unclosed quotes not supported by momoshell"));
-	// lexer->idx++;
 	start = lexer->idx + 1;
-	// if (type == TOK_DQUOTE && lexer->str[start] == CH_EXPAND)
-	// 	lexer->expansions++;
 	while (lexer->str[lexer->idx + 1] != quote)
 	{
 		lexer->idx++;

--- a/srcs/lexer/lex_space.c
+++ b/srcs/lexer/lex_space.c
@@ -15,6 +15,7 @@ bool	lex_space(t_lexer *lexer, t_toktype type)
 	new->exp_count = 0;
 	new->type = type;
 	new->state = S_SPACE;
+	new->flags |= F_SPACE;
 	if (token_append(&(lexer->tokens), new))
 		exit(EXIT_FAILURE);
 	switch_state(lexer, get_state(lexer->str[lexer->idx + 1]));

--- a/srcs/lexer/lex_space.c
+++ b/srcs/lexer/lex_space.c
@@ -3,9 +3,20 @@
 
 bool	lex_space(t_lexer *lexer, t_toktype type)
 {
-	(void)type;
+	t_token	*new;
+
 	while (lexer->state == get_state(lexer->str[lexer->idx + 1]))
 		lexer->idx++;
+	new = ft_calloc(1, sizeof(t_token));
+	check_malloc(new, "lex_space");
+	new->prev = NULL;
+	new->next = NULL;
+	new->word = NULL;
+	new->exp_count = 0;
+	new->type = type;
+	new->state = S_SPACE;
+	if (token_append(&(lexer->tokens), new))
+		exit(EXIT_FAILURE);
 	switch_state(lexer, get_state(lexer->str[lexer->idx + 1]));
 	return (false);
 }

--- a/srcs/lexer/lex_word.c
+++ b/srcs/lexer/lex_word.c
@@ -1,9 +1,5 @@
 
-#include "lexer.h"
-
-bool		error_msg(char *msg);
-// static bool	st_lex_quote(t_lexer *lex, int quote);
-// static bool	st_right_state(t_lexer *lex);
+#include "minishell.h"
 
 bool	lex_word(t_lexer *lexer, t_toktype type)
 {
@@ -20,28 +16,3 @@ bool	lex_word(t_lexer *lexer, t_toktype type)
 	switch_state(lexer, get_state(lexer->str[lexer->idx + 1]));
 	return (false);
 }
-
-// static bool	st_lex_quote(t_lexer *lex, int quote)
-// {
-// 	size_t	start;
-
-// 	lex->idx++;
-// 	start = lex->idx;
-// 	if (quote == CH_DQUOTE && lex->str[start] == CH_EXPAND)
-// 		lex->expansions++;
-// 	while (lex->str[lex->idx + 1] && lex->str[lex->idx + 1] != quote)
-// 	{
-// 		lex->idx++;
-// 		if (quote == CH_DQUOTE && lex->str[lex->idx] == CH_EXPAND)
-// 			lex->expansions++;
-// 	}
-// 	// lex->idx++;
-// 	return (false);
-// }
-
-// static bool	st_right_state(t_lexer *lex)
-// {
-// 	if (lex->str[lex->idx] == CH_SQUOTE || lex->str[lex->idx] == CH_DQUOTE)
-// 		return (true);
-// 	return (lex->state == get_state(lex->str[lex->idx + 1]));
-// }

--- a/srcs/lexer/lex_word.c
+++ b/srcs/lexer/lex_word.c
@@ -2,26 +2,18 @@
 #include "lexer.h"
 
 bool		error_msg(char *msg);
-static bool	st_lex_quote(t_lexer *lex, int quote);
-static bool	st_right_state(t_lexer *lex);
+// static bool	st_lex_quote(t_lexer *lex, int quote);
+// static bool	st_right_state(t_lexer *lex);
 
 bool	lex_word(t_lexer *lexer, t_toktype type)
 {
 	size_t	start;
 
 	start = lexer->idx;
-	while (st_right_state(lexer))
+	while (lexer->state == get_state(lexer->str[lexer->idx + 1]))
 	{
-		if (lexer->str[lexer->idx] == CH_SQUOTE || lexer->str[lexer->idx] == CH_DQUOTE)
-		{
-			if (st_lex_quote(lexer, lexer->str[lexer->idx]))
-				return (true);
-		}
-		else
-		{
-			if (lexer->str[lexer->idx] == CH_EXPAND)
-				lexer->expansions++;
-		}
+		if (lexer->str[lexer->idx] == CH_EXPAND)
+			lexer->expansions++;
 		lexer->idx++;
 	}
 	delimit_token(lexer, start, type);
@@ -29,29 +21,27 @@ bool	lex_word(t_lexer *lexer, t_toktype type)
 	return (false);
 }
 
-static bool	st_lex_quote(t_lexer *lex, int quote)
-{
-	size_t	start;
+// static bool	st_lex_quote(t_lexer *lex, int quote)
+// {
+// 	size_t	start;
 
-	lex->idx++;
-	if (!ft_strchr(lex->str + lex->idx, quote))
-		return (error_msg("Unclosed quotes not supported by momoshell"));
-	start = lex->idx;
-	if (quote == CH_DQUOTE && lex->str[start] == CH_EXPAND)
-		lex->expansions++;
-	while (lex->str[lex->idx + 1] && lex->str[lex->idx + 1] != quote)
-	{
-		lex->idx++;
-		if (quote == CH_DQUOTE && lex->str[lex->idx] == CH_EXPAND)
-			lex->expansions++;
-	}
-	// lex->idx++;
-	return (false);
-}
+// 	lex->idx++;
+// 	start = lex->idx;
+// 	if (quote == CH_DQUOTE && lex->str[start] == CH_EXPAND)
+// 		lex->expansions++;
+// 	while (lex->str[lex->idx + 1] && lex->str[lex->idx + 1] != quote)
+// 	{
+// 		lex->idx++;
+// 		if (quote == CH_DQUOTE && lex->str[lex->idx] == CH_EXPAND)
+// 			lex->expansions++;
+// 	}
+// 	// lex->idx++;
+// 	return (false);
+// }
 
-static bool	st_right_state(t_lexer *lex)
-{
-	if (lex->str[lex->idx] == CH_SQUOTE || lex->str[lex->idx] == CH_DQUOTE)
-		return (true);
-	return (lex->state == get_state(lex->str[lex->idx + 1]));
-}
+// static bool	st_right_state(t_lexer *lex)
+// {
+// 	if (lex->str[lex->idx] == CH_SQUOTE || lex->str[lex->idx] == CH_DQUOTE)
+// 		return (true);
+// 	return (lex->state == get_state(lex->str[lex->idx + 1]));
+// }

--- a/srcs/lexer/lexer.c
+++ b/srcs/lexer/lexer.c
@@ -6,6 +6,8 @@ static t_toktype	s_get_type(t_lexstate state)
 {
 	static const t_toktype	s_type[] = {
 	[S_SPACE] = TOK_SPACE,
+	[S_SQUOTE] = TOK_SQUOTE,
+	[S_DQUOTE] = TOK_DQUOTE,
 	[S_REDIR_IN] = TOK_REDIR_IN,
 	[S_REDIR_OUT] = TOK_REDIR_OUT,
 	[S_PIPE] = TOK_PIPE,
@@ -21,6 +23,8 @@ static bool	s_lexfunction(t_lexer *lexer, t_toktype type)
 	static const t_lexfunction lex[] = {
 		[TOK_SPACE] = &lex_space,
 		[TOK_WRD] = &lex_word,
+		[TOK_SQUOTE] = &lex_quote,
+		[TOK_DQUOTE] = &lex_quote,
 		[TOK_REDIR_IN] = &lex_operator,
 		[TOK_REDIR_OUT] = &lex_operator,
 		[TOK_PIPE] = &lex_operator

--- a/srcs/lexer/state_type.c
+++ b/srcs/lexer/state_type.c
@@ -11,9 +11,9 @@ t_lexstate	get_state(int c)
 		return (S_SQUOTE);
 	if (c == CH_DQUOTE)
 		return (S_DQUOTE);
-	if (c == CH_REDIR_IN)
+	if (c == CH_LESS)
 		return (S_REDIR_IN);
-	if (c == CH_REDIR_OUT)
+	if (c == CH_GREAT)
 		return (S_REDIR_OUT);
 	if (c == CH_PIPE)
 		return (S_PIPE);

--- a/srcs/lexer/state_type.c
+++ b/srcs/lexer/state_type.c
@@ -7,6 +7,10 @@ t_lexstate	get_state(int c)
 		return (S_EOF);
 	if (ft_isspace(c))
 		return (S_SPACE);
+	if (c == CH_SQUOTE)
+		return (S_SQUOTE);
+	if (c == CH_DQUOTE)
+		return (S_DQUOTE);
 	if (c == CH_REDIR_IN)
 		return (S_REDIR_IN);
 	if (c == CH_REDIR_OUT)

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -25,7 +25,7 @@ void	enter_shell(char **argv, char **envp)
 	}
 }
 
-// int	prompt(t_lexer *lexer)
+// int	prompt(t_lexer *lex er)
 // {
 // 	g_state = COMMAND;
 // 	init_signals(); // ? testing

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -13,12 +13,13 @@ void	enter_shell(char **argv, char **envp)
 	{
 		if (!lexer(&data.lexer))
 		{
-			expander(data.envp, &data.lexer);
-			if (!parser(data.lexer.tokens, &data.cmd))
-			{
-				g_state = EXECUTING;
-				executor(&data);
-			}
+			token_printHtT(data.lexer.tokens);
+			// expander(data.envp, &data.lexer);
+			// if (!parser(data.lexer.tokens, &data.cmd))
+			// {
+				// g_state = EXECUTING;
+				// executor(&data);
+			// }
 		}
 		reinit_data(&data);
 	}

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -14,7 +14,7 @@ void	enter_shell(char **argv, char **envp)
 		if (!lexer(&data.lexer))
 		{
 			token_printHtT(data.lexer.tokens);
-			// expander(data.envp, &data.lexer);
+			expander(data.envp, &data.lexer);
 			if (!parser(data.lexer.tokens, &data.cmd))
 			{
 				g_state = EXECUTING;

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -15,11 +15,11 @@ void	enter_shell(char **argv, char **envp)
 		{
 			token_printHtT(data.lexer.tokens);
 			// expander(data.envp, &data.lexer);
-			// if (!parser(data.lexer.tokens, &data.cmd))
-			// {
-				// g_state = EXECUTING;
-				// executor(&data);
-			// }
+			if (!parser(data.lexer.tokens, &data.cmd))
+			{
+				g_state = EXECUTING;
+				executor(&data);
+			}
 		}
 		reinit_data(&data);
 	}

--- a/srcs/parser/parse_args.c
+++ b/srcs/parser/parse_args.c
@@ -22,13 +22,19 @@ bool	parse_args(t_token **token, t_cmd *cmd)
 static int	s_get_argc(t_token *token)
 {
 	int		i;
+	int		flags;
 	t_token	*tmp;
+
 
 	i = 0;
 	tmp = token;
-	while (tmp && tmp->type == TOK_WRD)
+	while (tmp)
 	{
-		i++;
+		flags = tmp->flags;
+		if (flags & (F_WORD + F_SQUOTE + F_DQUOTE))
+			i++;
+		else if (flags & F_OPERATOR)
+			break ;
 		tmp = tmp->next;
 	}
 	return (i);
@@ -37,16 +43,20 @@ static int	s_get_argc(t_token *token)
 static bool	s_add_args(t_token **token, t_cmd *cmd)
 {
 	int	i;
+	int	flags;
 
 	i = 0;
-	// cmd->cmd = ft_strdup()
 	while (i < cmd->argc)
 	{
-		cmd->args[i] = ft_strdup((*token)->word);
-		if (!cmd->args[i])
-			exit_minishell(MALLOC_ERR);
+		flags = (*token)->flags;
+		if (flags & (F_WORD + F_SQUOTE + F_DQUOTE))
+		{
+			cmd->args[i] = ft_strdup((*token)->word);
+			if (!cmd->args[i])
+				exit_minishell(MALLOC_ERR);
+			i++;
+		}
 		*token = (*token)->next;
-		i++;
 	}
 	return (false);
 }

--- a/srcs/parser/parse_args.c
+++ b/srcs/parser/parse_args.c
@@ -22,7 +22,6 @@ bool	parse_args(t_token **token, t_cmd *cmd)
 static int	s_get_argc(t_token *token)
 {
 	int		i;
-	int		flags;
 	t_token	*tmp;
 
 
@@ -30,10 +29,9 @@ static int	s_get_argc(t_token *token)
 	tmp = token;
 	while (tmp)
 	{
-		flags = tmp->flags;
-		if (flags & (F_WORD + F_SQUOTE + F_DQUOTE))
+		if (tmp->flags & (F_WORD + F_SQUOTE + F_DQUOTE))
 			i++;
-		else if (flags & F_OPERATOR)
+		else if (tmp->flags & F_OPERATOR)
 			break ;
 		tmp = tmp->next;
 	}

--- a/srcs/parser/parse_args.c
+++ b/srcs/parser/parse_args.c
@@ -13,8 +13,7 @@ bool	parse_args(t_token **token, t_cmd *cmd)
 		return (error_msg("Syntax error encountered in parse_args"));
 	current->argc = s_get_argc(*token);
 	current->args = malloc(sizeof(char *) * (current->argc + 1));
-	if (!current->args)
-		exit_minishell(MALLOC_ERR);
+	check_malloc(current->args, "parse_args");
 	current->args[current->argc] = NULL;
 	return (s_add_args(token, current));
 }
@@ -23,7 +22,6 @@ static int	s_get_argc(t_token *token)
 {
 	int		i;
 	t_token	*tmp;
-
 
 	i = 0;
 	tmp = token;
@@ -41,17 +39,14 @@ static int	s_get_argc(t_token *token)
 static bool	s_add_args(t_token **token, t_cmd *cmd)
 {
 	int	i;
-	int	flags;
 
 	i = 0;
 	while (i < cmd->argc)
 	{
-		flags = (*token)->flags;
-		if (flags & (F_WORD + F_SQUOTE + F_DQUOTE))
+		if ((*token)->flags & (F_WORD + F_SQUOTE + F_DQUOTE))
 		{
 			cmd->args[i] = ft_strdup((*token)->word);
-			if (!cmd->args[i])
-				exit_minishell(MALLOC_ERR);
+			check_malloc(cmd->args[i], "s_add_args");
 			i++;
 		}
 		*token = (*token)->next;

--- a/srcs/parser/parse_pipe.c
+++ b/srcs/parser/parse_pipe.c
@@ -6,7 +6,7 @@
 /*   By: nsterk <nsterk@student.codam.nl>             +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2023/01/31 20:31:59 by nsterk        #+#    #+#                 */
-/*   Updated: 2023/06/06 11:53:42 by nsterk        ########   odam.nl         */
+/*   Updated: 2023/06/07 17:49:08 by nsterk        ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -32,8 +32,8 @@ bool	parse_redir(t_token **token, t_cmd *cmd)
 {
 	t_cmd	*current;
 
-	if (!((*token)->next) || (*token)->next->type != TOK_WRD)
-		return (error_msg("syntax error encountered in parse_redir"));
+	if (syntax_red(cmd, *token))
+		return (true);
 	current = cmd_last(cmd);
 	if ((*token)->type == TOK_REDIR_IN && s_add_redir(token, &(current->in), RED_IPUT))
 		exit_error(1, "parse_redir-in", "malloc failure");
@@ -48,12 +48,13 @@ static bool	s_add_redir(t_token **token, t_red **red, t_red_type type)
 	t_red	*new;
 
 	new = malloc(sizeof(t_red));
-	if (!new)
-		return (1);
+	check_malloc(new, "s_add_redir");
 	new->next = NULL;
 	new->type = type;
-	if (ft_strlen((*token)->word) == 2)
+	if ((*token)->flags & F_APPEND)
 		new->type++;
+	if ((*token)->next->flags & F_SPACE)
+		*token = (*token)->next;
 	new->filename = ft_strdup((*token)->next->word);
 	if (!new->filename)
 		return (true);

--- a/srcs/parser/parse_pipe.c
+++ b/srcs/parser/parse_pipe.c
@@ -6,7 +6,7 @@
 /*   By: nsterk <nsterk@student.codam.nl>             +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2023/01/31 20:31:59 by nsterk        #+#    #+#                 */
-/*   Updated: 2023/04/22 17:53:17 by nsterk        ########   odam.nl         */
+/*   Updated: 2023/06/06 11:53:42 by nsterk        ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -41,7 +41,7 @@ bool	parse_redir(t_token **token, t_cmd *cmd)
 		exit_error(1, "parse_redir-out", "malloc failure");
 	*token = (*token)->next;
 	return (false);
-}
+} 
 
 static bool	s_add_redir(t_token **token, t_red **red, t_red_type type)
 {

--- a/srcs/parser/parser.c
+++ b/srcs/parser/parser.c
@@ -24,7 +24,7 @@ bool	parser(t_token *token, t_cmd **cmd)
 
 static bool	s_parse_command(t_token **token, t_cmd **cmd)
 {
-	if ((*token)->type == TOK_WRD || (*token)->type == TOK_SQUOTE || (*token)->type == TOK_DQUOTE)
+	if ((*token)->flags & F_WORD)
 		return (parse_args(token, *cmd));
 	if ((*token)->type == TOK_REDIR_IN || (*token)->type == TOK_REDIR_OUT)
 		return (parse_redir(token, *cmd));

--- a/srcs/parser/parser.c
+++ b/srcs/parser/parser.c
@@ -13,7 +13,9 @@ bool	parser(t_token *token, t_cmd **cmd)
 	check_malloc(*cmd, "parser");
 	while (tmp)
 	{
-		if (s_parse_command(&tmp, cmd))
+		if (tmp->type == TOK_SPACE)
+			tmp = tmp->next;
+		else if (s_parse_command(&tmp, cmd))
 			return (true);
 	}
 	// print_tbl(*cmd);
@@ -22,7 +24,7 @@ bool	parser(t_token *token, t_cmd **cmd)
 
 static bool	s_parse_command(t_token **token, t_cmd **cmd)
 {
-	if ((*token)->type == TOK_WRD)
+	if ((*token)->type == TOK_WRD || (*token)->type == TOK_SQUOTE || (*token)->type == TOK_DQUOTE)
 		return (parse_args(token, *cmd));
 	if ((*token)->type == TOK_REDIR_IN || (*token)->type == TOK_REDIR_OUT)
 		return (parse_redir(token, *cmd));

--- a/srcs/parser/parser.c
+++ b/srcs/parser/parser.c
@@ -15,10 +15,10 @@ bool	parser(t_token *token, t_cmd **cmd)
 	{
 		if (tmp->type == TOK_SPACE)
 			tmp = tmp->next;
-		else if (s_parse_command(&tmp, cmd))
+		if (s_parse_command(&tmp, cmd))
 			return (true);
 	}
-	// print_tbl(*cmd);
+	print_tbl(*cmd);
 	return (false);
 }
 

--- a/srcs/parser/syntax_rules.c
+++ b/srcs/parser/syntax_rules.c
@@ -1,11 +1,6 @@
 
 #include "minishell.h"
 
-/**
- * valid scenarios:
- * 		1: token->next is space and token->next->next is word
- * 		2: token->next is word
- */
 bool	syntax_red(t_cmd *cmd, t_token *token) //! no idea why i'm passing the cmd too probably need to remove
 {
 	t_token	*tmp;

--- a/srcs/parser/syntax_rules.c
+++ b/srcs/parser/syntax_rules.c
@@ -1,11 +1,24 @@
 
 #include "minishell.h"
 
-bool	syntax_red(t_cmd *cmd, t_token *token)
+/**
+ * valid scenarios:
+ * 		1: token->next is space and token->next->next is word
+ * 		2: token->next is word
+ */
+bool	syntax_red(t_cmd *cmd, t_token *token) //! no idea why i'm passing the cmd too probably need to remove
 {
-	(void)cmd;
-	if (!token->next)
+	t_token	*tmp;
+
+	tmp = token;
+	if (!tmp->next)
 		return (error_msg("syntax error near unexpected token 'newline'"));
+	if (tmp->next->flags & F_SPACE)
+		tmp = tmp->next;
+	if (!tmp->next)
+		return (error_msg("syntax error near unexpected token 'newline'"));
+	if (tmp->next->flags & F_OPERATOR)
+		return (error_msg("syntax error near unexpected token 'operator'"));
 	return (false);
 }
 

--- a/srcs/utils/libft/ft_replace.c
+++ b/srcs/utils/libft/ft_replace.c
@@ -1,0 +1,32 @@
+
+#include "utils.h"
+
+char *ft_replace(char *dst, char *src, size_t start, size_t end)
+{
+	char	*front;
+	char	*back;
+
+	if (!dst)
+		return (NULL);
+	front = ft_substr(dst, 0, start);
+	front = strjoin_free(front, src);
+	back = ft_substr(dst, end + 1, ft_strlen(dst) - end);
+	front = strjoin_free(front, back);
+	free(dst);
+	free(back);
+	return (front);
+}
+
+// int	main(void)
+// {
+// 	char *test;
+// 	char *env;
+
+// 	test = ft_strndup("this$is$a$test", 14);
+// 	env = ft_strndup("FLAP", 4);
+// 	printf("%s\n", test);
+// 	test = ft_replace(test, env, 4, 6);
+// 	printf("%s\n", test);
+// 	free(test);
+// 	return (0);
+// }

--- a/srcs/utils/libft/ft_substr.c
+++ b/srcs/utils/libft/ft_substr.c
@@ -1,0 +1,26 @@
+
+#include "utils.h"
+
+char	*ft_substr(char const *s, size_t start, size_t len)
+{
+	size_t	i;
+	char	*sub;
+
+	if (!s)
+		return (NULL);
+	if ((ft_strlen(s) - start) < len)
+		len = ft_strlen(s) - start;
+	if (start >= ft_strlen(s))
+		len = 0;
+	sub = (char *)malloc(sizeof(*s) * (len + 1));
+	if (!sub)
+		return (NULL);
+	i = 0;
+	while (s[start + i] != '\0' && i < len)
+	{
+		sub[i] = s[start + i];
+		i++;
+	}
+	sub[i] = '\0';
+	return (sub);
+}

--- a/srcs/utils/strjoin_free.c
+++ b/srcs/utils/strjoin_free.c
@@ -10,11 +10,14 @@ char	*strjoin_free(char *s1, char *s2)
 	len1 = ft_strlen(s1);
 	len2 = ft_strlen(s2);
 	str = (char *)ft_calloc(len1 + len2 + 1, sizeof(char));
-	if (!str)
-		return (NULL);
-	ft_memcpy(str, s1, len1);
-	ft_memcpy(str + len1, s2, len2);
-	free(s1);
-	free(s2);
+	if (str)
+	{
+		ft_memcpy(str, s1, len1);
+		ft_memcpy(str + len1, s2, len2);
+	}
+	if (s1)
+		free(s1);
+	if (s2)
+		free(s2);
 	return (str);
 }

--- a/srcs/utils/tokens/test_list.c
+++ b/srcs/utils/tokens/test_list.c
@@ -12,6 +12,7 @@ void	token_printHtT(t_token *lst)
 	{
 		printf("%s", tmp->word);
 		printf(" (state: %d)", tmp->state);
+		printf(" expansions: %zu", tmp->exp_count);
 		if (tmp->next)
 			printf(RED" - "RST);
 		tmp = tmp->next;


### PR DESCRIPTION
I did things

such as:
- new structure for lexer and parser, we now also have space tokens
- add ft_replace function which will be very useful, in an entirely different feature (expander)

What did I not do:
- actually fix the initial quote problem which was that quotes were seen as separate tokens. This is still the case but now it's on purpose, and it will be handled after expansions. Which is why I'm closing this PR to open a new on and continue on expander first
